### PR TITLE
Support for heroku-24 stack

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -57,41 +57,54 @@ case "$channel" in
     ;;
 esac
 
-# Install correct dependencies according to $STACK
+BASE_PACKAGES="
+  libatk1.0-0
+  libatk-bridge2.0-0
+  libcairo-gobject2
+  libdrm2
+  libgbm1
+  libgtk-3-0
+  libnspr4
+  libnss3
+  libx11-xcb1
+  libxcb-dri3-0
+  libxcomposite1
+  libxcursor1
+  libxdamage1
+  libxfixes3
+  libxi6
+  libxinerama1
+  libxrandr2
+  libxshmfence1
+  libxss1
+  libxtst6
+  fonts-liberation
+"
+
 case "${STACK}" in
-  "heroku-18" | "heroku-20" | "heroku-22" | "heroku-24")
-    # the package list is found by using ci:debug then running ldd $GOOGLE_CHROME_BIN | grep not
-    # also look here for more packages/notes https://developers.google.com/web/tools/puppeteer/troubleshooting
-    PACKAGES="
+  "heroku-20")
+    PACKAGES="${BASE_PACKAGES}
       gconf-service
       libappindicator1
       libasound2
-      libatk1.0-0
-      libatk-bridge2.0-0
-      libcairo-gobject2
-      libdrm2
-      libgbm1
       libgconf-2-4
-      libgtk-3-0
-      libnspr4
-      libnss3
-      libx11-xcb1
-      libxcb-dri3-0
-      libxcomposite1
-      libxcursor1
-      libxdamage1
-      libxfixes3
-      libxi6
-      libxinerama1
-      libxrandr2
-      libxshmfence1
-      libxss1
-      libxtst6
-      fonts-liberation
+    "
+    ;;
+  "heroku-22")
+    PACKAGES="${BASE_PACKAGES}
+      libappindicator1
+      libasound2
+      libgconf-2-4
+    "
+    ;;
+  "heroku-24")
+    PACKAGES="${BASE_PACKAGES}
+      libasound2t64
     "
     ;;
   *)
-    error "STACK must be 'heroku-18', 'heroku-20' or 'heroku-22', not '${STACK}'."
+    error "STACK must be 'heroku-20', 'heroku-22' or 'heroku-24', not '${STACK}'."
+    ;;
 esac
 
 if [ ! -f $CACHE_DIR/PURGED_CACHE_V1 ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -59,7 +59,7 @@ esac
 
 # Install correct dependencies according to $STACK
 case "${STACK}" in
-  "heroku-18" | "heroku-20" | "heroku-22")
+  "heroku-18" | "heroku-20" | "heroku-22" | "heroku-24")
     # the package list is found by using ci:debug then running ldd $GOOGLE_CHROME_BIN | grep not
     # also look here for more packages/notes https://developers.google.com/web/tools/puppeteer/troubleshooting
     PACKAGES="


### PR DESCRIPTION
This PR adds support for **heroku-24**

`heroku-24` is based on Ubuntu 24.04 and some libraries are now non-existent (and needless) while some others have changed.  
This PR fixes the package installation such that it will work on all our stacks
